### PR TITLE
feat: 면접 재개, 중단, 완료 api 구현

### DIFF
--- a/src/featured/interview/actions/interview.action.ts
+++ b/src/featured/interview/actions/interview.action.ts
@@ -6,18 +6,20 @@ import {
   createInterview,
   startInterview,
   pauseInterview,
+  resumeInterview,
+  finishInterview,
 } from '@/featured/interview/services/interview.service'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
 
+// 면접 생성
 export async function createInterviewAction(
   title: string,
 ): Promise<ApiResponse<CreateInterviewResponse>> {
   return createInterview(title)
 }
 
-export async function startInterviewAction(
-  intvId: number,
-): Promise<ApiResponse<null>> {
+// 면접 시작
+export async function startInterviewAction(intvId: number): Promise<ApiResponse<null>> {
   try {
     return await startInterview(intvId)
   } catch (error) {
@@ -26,11 +28,30 @@ export async function startInterviewAction(
   }
 }
 
-export async function pauseInterviewAction(
-  intvId: number,
-): Promise<ApiResponse<null>> {
+// 면접 중단
+export async function pauseInterviewAction(intvId: number): Promise<ApiResponse<null>> {
   try {
     return await pauseInterview(intvId)
+  } catch (error) {
+    if (isRedirectError(error)) throw error
+    throw error
+  }
+}
+
+// 면접 재개
+export async function resumeInterviewAction(intvId: number): Promise<ApiResponse<null>> {
+  try {
+    return await resumeInterview(intvId)
+  } catch (error) {
+    if (isRedirectError(error)) throw error
+    throw error
+  }
+}
+
+// 면접 완료
+export async function finishInterviewAction(intvId: number): Promise<ApiResponse<null>> {
+  try {
+    return await finishInterview(intvId)
   } catch (error) {
     if (isRedirectError(error)) throw error
     throw error

--- a/src/featured/interview/actions/interview.action.ts
+++ b/src/featured/interview/actions/interview.action.ts
@@ -5,6 +5,7 @@ import type { CreateInterviewResponse } from '../types'
 import {
   createInterview,
   startInterview,
+  pauseInterview,
 } from '@/featured/interview/services/interview.service'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
 
@@ -19,6 +20,17 @@ export async function startInterviewAction(
 ): Promise<ApiResponse<null>> {
   try {
     return await startInterview(intvId)
+  } catch (error) {
+    if (isRedirectError(error)) throw error
+    throw error
+  }
+}
+
+export async function pauseInterviewAction(
+  intvId: number,
+): Promise<ApiResponse<null>> {
+  try {
+    return await pauseInterview(intvId)
   } catch (error) {
     if (isRedirectError(error)) throw error
     throw error

--- a/src/featured/interview/components/EndDialogModal.tsx
+++ b/src/featured/interview/components/EndDialogModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import Link from 'next/link'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { Button } from '@/shared/ui/button'
 import {
   Dialog,
@@ -11,12 +12,33 @@ import {
   DialogFooter,
 } from '@/shared/ui/dialog'
 import type { useInterview } from '@/featured/interview/hooks/useInterview'
+import { pauseInterviewAction } from '@/featured/interview/actions/interview.action'
 
 interface EndDialogModalProps {
   session: ReturnType<typeof useInterview>
+  interviewId: number | null
 }
 
-export function EndDialogModal({ session }: EndDialogModalProps) {
+export function EndDialogModal({ session, interviewId }: EndDialogModalProps) {
+  const router = useRouter()
+  const [isPending, setIsPending] = useState(false)
+
+  const handlePause = async () => {
+    if (interviewId === null) {
+      router.push('/history')
+      return
+    }
+
+    setIsPending(true)
+    try {
+      await pauseInterviewAction(interviewId)
+    } finally {
+      // 무조건 router를 움직여야해서 catch 사용하지 않고 바로 finally로
+      setIsPending(false)
+      router.push('/history')
+    }
+  }
+
   return (
     <Dialog open={session.showEndDialog} onOpenChange={session.setShowEndDialog}>
       <DialogContent className="border-white/10 bg-slate-900 text-white">
@@ -35,11 +57,12 @@ export function EndDialogModal({ session }: EndDialogModalProps) {
             variant="ghost"
             className="text-white/70 hover:bg-white/10 hover:text-white"
             onClick={() => session.setShowEndDialog(false)}
+            disabled={isPending}
           >
             계속하기
           </Button>
-          <Button variant="destructive" asChild>
-            <Link href="/history">면접 중단</Link>
+          <Button variant="destructive" onClick={handlePause} disabled={isPending}>
+            면접 중단
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/featured/interview/components/InterviewContainer.tsx
+++ b/src/featured/interview/components/InterviewContainer.tsx
@@ -41,7 +41,7 @@ export function InterviewContainer({ session, interviewId }: InterviewPageProps)
           timeLeft={session.timeLeft}
           phase={session.phase}
         />
-        <FinishedOverlay phase={session.phase} />
+        <FinishedOverlay phase={session.phase} intvId={interviewId!} />
       </div>
       <ControlBar
         micOn={session.micOn}

--- a/src/featured/interview/components/InterviewLayout.tsx
+++ b/src/featured/interview/components/InterviewLayout.tsx
@@ -16,7 +16,7 @@ export function InterviewLayout() {
   return (
     <>
       <InterviewContainer session={session} interviewId={interviewId} />
-      <EndDialogModal session={session} />
+      <EndDialogModal session={session} interviewId={interviewId} />
       <InterviewSetupModal session={session} isResume={isResume} />
     </>
   )

--- a/src/featured/interview/components/interview/FinishedOverlay.tsx
+++ b/src/featured/interview/components/interview/FinishedOverlay.tsx
@@ -1,16 +1,28 @@
 'use client'
 
-import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Button } from '@/shared/ui/button'
 import { CheckCircle2, ChevronRight } from 'lucide-react'
 import type { Phase } from '@/featured/interview/types'
+import { finishInterviewAction } from '@/featured/interview/actions/interview.action'
 
 interface FinishedOverlayProps {
   phase: Phase
+  intvId: number
 }
 
-export function FinishedOverlay({ phase }: FinishedOverlayProps) {
+export function FinishedOverlay({ phase, intvId }: FinishedOverlayProps) {
+  const router = useRouter()
+
+  async function handleGoToHistory() {
+    try {
+      await finishInterviewAction(intvId)
+    } finally {
+      router.push('/history')
+    }
+  }
+
   return (
     <AnimatePresence>
       {phase === 'finished' && (
@@ -31,11 +43,9 @@ export function FinishedOverlay({ phase }: FinishedOverlayProps) {
                 분석 완료까지 <strong>약 3~5분이 소요</strong>되며, 면접 기록에서 확인 가능합니다.
               </p>
             </div>
-            <Button size="lg" className="mt-2 gap-2 px-8" asChild>
-              <Link href="/history">
-                나의 면접 기록 보기
-                <ChevronRight className="h-4 w-4" />
-              </Link>
+            <Button size="lg" className="mt-2 gap-2 px-8" onClick={handleGoToHistory}>
+              나의 면접 기록 보기
+              <ChevronRight className="h-4 w-4" />
             </Button>
           </div>
         </motion.div>

--- a/src/featured/interview/services/interview.service.ts
+++ b/src/featured/interview/services/interview.service.ts
@@ -9,16 +9,24 @@ export async function createInterview(
   })
 }
 
-export async function startInterview(
-  intvId: number,
-): Promise<ApiResponse<null>> {
+// 면접 시작
+export async function startInterview(intvId: number): Promise<ApiResponse<null>> {
   return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/start`)
 }
 
-export async function pauseInterview(
-  intvId: number,
-): Promise<ApiResponse<null>> {
+// 면저 중단
+export async function pauseInterview(intvId: number): Promise<ApiResponse<null>> {
   return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/pause`)
+}
+
+// 면접 재개
+export async function resumeInterview(intvId: number): Promise<ApiResponse<null>> {
+  return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/resume`)
+}
+
+// 면접 완료
+export async function finishInterview(intvId: number): Promise<ApiResponse<null>> {
+  return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/finish`)
 }
 
 // export async function updateInterviewTitle(id: number, title: string) {

--- a/src/featured/interview/services/interview.service.ts
+++ b/src/featured/interview/services/interview.service.ts
@@ -15,6 +15,12 @@ export async function startInterview(
   return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/start`)
 }
 
+export async function pauseInterview(
+  intvId: number,
+): Promise<ApiResponse<null>> {
+  return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/pause`)
+}
+
 // export async function updateInterviewTitle(id: number, title: string) {
 //   try {
 //     const data = await serverApi.patch<CreateInterviewResponse>(`/api/v1/intvs/${id}`, { title })


### PR DESCRIPTION
## 변경 사항

- 면접 중단
    - api service함수 정의
    - api action 함수 정의 
    - 버튼에 api 부착
- 면접 재개
    - api service함수 정의
    - api action 함수 정의 
- 면접 완료
    - api service함수 정의
    - api action 함수 정의
    - 완료 버튼에 api 부착

## 리뷰 필요

- service 함수 확인 필요
- action 함수 확인 필요
- 각 버튼에 붙은 로직 확인 필요

close #116 
