### PR TITLE
feat: 공지사항 api 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7143,6 +7143,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/(authenticated)/(sidebar)/notices/[id]/page.tsx
+++ b/src/app/(authenticated)/(sidebar)/notices/[id]/page.tsx
@@ -15,7 +15,7 @@ export default async function NoticeDetailPage({ params }: NoticeDetailPageProps
   const detailResult = await getNoticeDetailAction(noticeId)
 
   if (!detailResult.success || !detailResult.data) {
-    notFound()
+    return notFound()
   }
 
   const notice = detailResult.data

--- a/src/app/(authenticated)/(sidebar)/notices/[id]/page.tsx
+++ b/src/app/(authenticated)/(sidebar)/notices/[id]/page.tsx
@@ -1,9 +1,7 @@
-// app/notices/[id]/page.tsx
 import { notFound } from 'next/navigation'
 import { NoticeHeader } from '@/featured/notice/components/NoticeHeader'
 import { NoticeDetail } from '@/featured/notice/components/NoticeDetail'
 
-// 1. 가짜 데이터 대신 진짜 데이터를 가져올 Action 함수들을 불러옵니다.
 import { getNoticeDetailAction, getNoticesAction } from '@/featured/notice/actions/notice.action'
 
 interface NoticeDetailPageProps {
@@ -11,31 +9,25 @@ interface NoticeDetailPageProps {
 }
 
 export default async function NoticeDetailPage({ params }: NoticeDetailPageProps) {
-  // 2. 주소창(URL)에 있는 id 값을 꺼내서 숫자로 바꿉니다. (예: /notices/1 -> 1)
   const { id } = await params
   const noticeId = Number(id)
 
-  // 3. 진짜 상세 데이터를 서버에 요청합니다.
   const detailResult = await getNoticeDetailAction(noticeId)
 
-  // 4. 만약 통신이 실패했거나, 해당 id의 공지사항이 없으면 404 페이지로 보냅니다.
   if (!detailResult.success || !detailResult.data) {
     notFound()
   }
 
   const notice = detailResult.data
 
-  // 5. '이전 글 / 다음 글'을 찾기 위해 전체 목록 데이터를 살짝 가져옵니다.
   const listResult = await getNoticesAction()
   let prevNotice = null
   let nextNotice = null
 
   if (listResult.success && listResult.data) {
-    // 여기서 n 에러가 해결됩니다! listResult.data가 Notice[] 라는 것을 컴퓨터가 이미 알고 있습니다.
     const idx = listResult.data.findIndex((n) => n.id === noticeId)
 
     if (idx !== -1) {
-      // 내 위치(idx)를 기준으로 앞(idx - 1)과 뒤(idx + 1)의 글을 찾습니다.
       prevNotice = idx > 0 ? listResult.data[idx - 1] : null
       nextNotice = idx < listResult.data.length - 1 ? listResult.data[idx + 1] : null
     }
@@ -44,7 +36,6 @@ export default async function NoticeDetailPage({ params }: NoticeDetailPageProps
   return (
     <>
       <NoticeHeader />
-      {/* 6. 찾아낸 진짜 데이터들을 컴포넌트에 쏙 넣어줍니다. */}
       <NoticeDetail notice={notice} prevNotice={prevNotice} nextNotice={nextNotice} />
     </>
   )

--- a/src/app/(authenticated)/(sidebar)/notices/[id]/page.tsx
+++ b/src/app/(authenticated)/(sidebar)/notices/[id]/page.tsx
@@ -1,27 +1,50 @@
+// app/notices/[id]/page.tsx
 import { notFound } from 'next/navigation'
 import { NoticeHeader } from '@/featured/notice/components/NoticeHeader'
 import { NoticeDetail } from '@/featured/notice/components/NoticeDetail'
-import { MOCK_NOTICES } from '@/featured/notice/types'
+
+// 1. 가짜 데이터 대신 진짜 데이터를 가져올 Action 함수들을 불러옵니다.
+import { getNoticeDetailAction, getNoticesAction } from '@/featured/notice/actions/notice.action'
 
 interface NoticeDetailPageProps {
   params: Promise<{ id: string }>
 }
 
 export default async function NoticeDetailPage({ params }: NoticeDetailPageProps) {
+  // 2. 주소창(URL)에 있는 id 값을 꺼내서 숫자로 바꿉니다. (예: /notices/1 -> 1)
   const { id } = await params
-  const idx = MOCK_NOTICES.findIndex((n) => n.id === Number(id))
+  const noticeId = Number(id)
 
-  if (idx === -1) {
+  // 3. 진짜 상세 데이터를 서버에 요청합니다.
+  const detailResult = await getNoticeDetailAction(noticeId)
+
+  // 4. 만약 통신이 실패했거나, 해당 id의 공지사항이 없으면 404 페이지로 보냅니다.
+  if (!detailResult.success || !detailResult.data) {
     notFound()
   }
 
-  const notice = MOCK_NOTICES[idx]
-  const prevNotice = idx > 0 ? MOCK_NOTICES[idx - 1] : null
-  const nextNotice = idx < MOCK_NOTICES.length - 1 ? MOCK_NOTICES[idx + 1] : null
+  const notice = detailResult.data
+
+  // 5. '이전 글 / 다음 글'을 찾기 위해 전체 목록 데이터를 살짝 가져옵니다.
+  const listResult = await getNoticesAction()
+  let prevNotice = null
+  let nextNotice = null
+
+  if (listResult.success && listResult.data) {
+    // 여기서 n 에러가 해결됩니다! listResult.data가 Notice[] 라는 것을 컴퓨터가 이미 알고 있습니다.
+    const idx = listResult.data.findIndex((n) => n.id === noticeId)
+
+    if (idx !== -1) {
+      // 내 위치(idx)를 기준으로 앞(idx - 1)과 뒤(idx + 1)의 글을 찾습니다.
+      prevNotice = idx > 0 ? listResult.data[idx - 1] : null
+      nextNotice = idx < listResult.data.length - 1 ? listResult.data[idx + 1] : null
+    }
+  }
 
   return (
     <>
       <NoticeHeader />
+      {/* 6. 찾아낸 진짜 데이터들을 컴포넌트에 쏙 넣어줍니다. */}
       <NoticeDetail notice={notice} prevNotice={prevNotice} nextNotice={nextNotice} />
     </>
   )

--- a/src/app/(authenticated)/(sidebar)/notices/page.tsx
+++ b/src/app/(authenticated)/(sidebar)/notices/page.tsx
@@ -1,31 +1,23 @@
 import { NoticeHeader } from '@/featured/notice/components/NoticeHeader'
 import { NoticeClient } from '@/featured/notice/components/NoticeClient'
-import type { Notice } from '@/featured/notice/types' // 타입도 가져옵니다.
-
-// [수정 1] 캡처 화면의 폴더 구조에 맞게 파일 이름(notice.action)까지 정확하게 적어줍니다.
+import type { Notice } from '@/featured/notice/types'
 import { getNoticesAction } from '@/featured/notice/actions/notice.action'
 
 export default async function NoticePage() {
-  // [수정 2] 만약 에러가 나더라도 화면이 터지지 않게, 기본값을 '빈 배열'로 미리 준비해 둡니다.
   let fetchedNotices: Notice[] = []
-
-  // [수정 3] Action에서 던지는 에러(throw)를 막기 위해 try...catch 방패를 씌웁니다.
   try {
     const result = await getNoticesAction()
 
-    // 통신이 성공하고 데이터가 있으면, 미리 준비한 변수에 진짜 데이터를 덮어씌웁니다.
     if (result.success && result.data) {
       fetchedNotices = result.data
     }
   } catch (error) {
-    // 서버 통신에 실패해도, try...catch가 막아주었기 때문에 빈 배열([])이 그대로 유지됩니다.
     console.error('공지사항 전체 페이지 불러오기 실패:', error)
   }
 
   return (
     <>
       <NoticeHeader />
-      {/* 정상일 때는 진짜 데이터가, 에러 났을 때는 빈 배열이 안전하게 들어갑니다. */}
       <NoticeClient initialNotices={fetchedNotices} />
     </>
   )

--- a/src/app/(authenticated)/(sidebar)/notices/page.tsx
+++ b/src/app/(authenticated)/(sidebar)/notices/page.tsx
@@ -1,11 +1,32 @@
 import { NoticeHeader } from '@/featured/notice/components/NoticeHeader'
 import { NoticeClient } from '@/featured/notice/components/NoticeClient'
+import type { Notice } from '@/featured/notice/types' // 타입도 가져옵니다.
 
-export default function NoticePage() {
+// [수정 1] 캡처 화면의 폴더 구조에 맞게 파일 이름(notice.action)까지 정확하게 적어줍니다.
+import { getNoticesAction } from '@/featured/notice/actions/notice.action'
+
+export default async function NoticePage() {
+  // [수정 2] 만약 에러가 나더라도 화면이 터지지 않게, 기본값을 '빈 배열'로 미리 준비해 둡니다.
+  let fetchedNotices: Notice[] = []
+
+  // [수정 3] Action에서 던지는 에러(throw)를 막기 위해 try...catch 방패를 씌웁니다.
+  try {
+    const result = await getNoticesAction()
+
+    // 통신이 성공하고 데이터가 있으면, 미리 준비한 변수에 진짜 데이터를 덮어씌웁니다.
+    if (result.success && result.data) {
+      fetchedNotices = result.data
+    }
+  } catch (error) {
+    // 서버 통신에 실패해도, try...catch가 막아주었기 때문에 빈 배열([])이 그대로 유지됩니다.
+    console.error('공지사항 전체 페이지 불러오기 실패:', error)
+  }
+
   return (
     <>
       <NoticeHeader />
-      <NoticeClient />
+      {/* 정상일 때는 진짜 데이터가, 에러 났을 때는 빈 배열이 안전하게 들어갑니다. */}
+      <NoticeClient initialNotices={fetchedNotices} />
     </>
   )
 }

--- a/src/featured/dashboard/actions/dashboard.action.ts
+++ b/src/featured/dashboard/actions/dashboard.action.ts
@@ -2,7 +2,7 @@
 
 import type { ApiResponse } from '@/shared/lib/api'
 import type { InterviewStat } from '../types'
-import type { Notice, NoticeDetail } from '@/featured/notice/types'
+import type { Notice, NoticeDetailResponse } from '@/featured/notice/types'
 
 import { getInterviewStats, getNotices, getNoticeDetail } from '../services/dashboard.service'
 
@@ -44,7 +44,9 @@ export async function getNoticesAction(): Promise<ApiResponse<Notice[]>> {
 }
 
 /** * 공지사항 상세 내용 조회 Action */
-export async function getNoticeDetailAction(noticeId: number): Promise<ApiResponse<NoticeDetail>> {
+export async function getNoticeDetailAction(
+  noticeId: number,
+): Promise<ApiResponse<NoticeDetailResponse>> {
   try {
     return await getNoticeDetail(noticeId)
   } catch (error) {

--- a/src/featured/dashboard/components/NoticeSection.tsx
+++ b/src/featured/dashboard/components/NoticeSection.tsx
@@ -33,8 +33,6 @@ export function NoticeSection() {
   useEffect(() => {
     async function fetchNotices() {
       setIsLoading(true)
-
-      // [수정 2] action에서 던진 에러(throw)를 잡기 위해 try...catch 블록을 추가합니다.
       try {
         const result = await getNoticesAction()
 
@@ -49,11 +47,9 @@ export function NoticeSection() {
           setNotices([])
         }
       } catch (error) {
-        // 서버가 터지는 등 치명적인 에러가 발생했을 때 화면이 깨지지 않도록 방어합니다.
         console.error('공지사항 통신 에러 발생:', error)
         setNotices([])
       } finally {
-        // 성공하든 실패하든 마지막에 로딩 상태를 끝냅니다.
         setIsLoading(false)
       }
     }

--- a/src/featured/dashboard/components/NoticeSection.tsx
+++ b/src/featured/dashboard/components/NoticeSection.tsx
@@ -21,12 +21,18 @@ const fadeUp = {
 export function NoticeSection() {
   const [notices, setNotices] = useState<Notice[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [now, setNow] = useState<number>(0)
 
   useEffect(() => {
     async function fetchNotices() {
       setIsLoading(true)
 
+      // 웨이터가 주방(서버)에 다녀옵니다. (여기서 약간의 시간이 걸림)
       const result = await getNoticesAction()
+
+      // [수정된 부분] 데이터가 도착한 직후에 시계를 보고 메모(now)합니다!
+      // 이렇게 서버 통신(비동기) 이후에 상태를 바꾸면, 리액트가 숨을 고를 수 있어서 에러가 안 납니다.
+      setNow(Date.now())
 
       if (result.success && result.data) {
         setNotices(result.data)
@@ -38,7 +44,7 @@ export function NoticeSection() {
     }
 
     fetchNotices()
-  }, [])
+  }, []) // 맨 위에 있던 setNow(Date.now())는 삭제했습니다!
 
   return (
     <motion.div
@@ -70,9 +76,9 @@ export function NoticeSection() {
             notices.map((item) => {
               const config = NOTICE_CATEGORY_CONFIG[item.category] || NOTICE_CATEGORY_CONFIG.NOTICE
 
-              // 작성일 기준 3일(72시간) 이내면 새 글로 취급하는 로직
+              // 여기서 메모해둔 now 값을 씁니다.
               const isRecent =
-                new Date(item.createdAt).getTime() > Date.now() - 3 * 24 * 60 * 60 * 1000
+                now > 0 && new Date(item.createdAt).getTime() > now - 3 * 24 * 60 * 60 * 1000
 
               return (
                 <Link
@@ -107,7 +113,6 @@ export function NoticeSection() {
               )
             })
           ) : (
-            // 데이터가 없거나 에러가 났을 때 공통으로 보여줄 UI
             <div className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
               새로운 공지사항이 없습니다.
             </div>

--- a/src/featured/dashboard/components/NoticeSection.tsx
+++ b/src/featured/dashboard/components/NoticeSection.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react'
 import { getNoticesAction } from '@/featured/notice/actions/notice.action'
 import type { Notice } from '@/featured/notice/types'
 import { NOTICE_CATEGORY } from '@/featured/notice/constants'
-import { formatDateDot } from '@/shared/lib/utils/date'
+import { formatDateDot, checkIsRecent } from '@/shared/lib/utils/date'
 
 const fadeUp = {
   hidden: { opacity: 0, y: 16 },
@@ -19,10 +19,6 @@ const fadeUp = {
   }),
 }
 
-const checkIsRecent = (dateString: string) => {
-  const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000
-  return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
-}
 
 type NoticeWithUI = Notice & { isRecent: boolean }
 

--- a/src/featured/dashboard/components/NoticeSection.tsx
+++ b/src/featured/dashboard/components/NoticeSection.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react'
 import { getNoticesAction } from '../actions/dashboard.action'
 import type { Notice } from '@/featured/notice/types'
 import { NOTICE_CATEGORY_CONFIG } from '@/featured/notice/constants'
-import { formatDateDot } from '@/shared/lib/utils/date' // 🍯 날짜 포맷 꿀팁!
+import { formatDateDot } from '@/shared/lib/utils/date'
 
 const fadeUp = {
   hidden: { opacity: 0, y: 16 },
@@ -19,17 +19,15 @@ const fadeUp = {
   }),
 }
 
-// ✅ 1. 로직 분리: 새 글(72시간 이내)인지 확인하는 함수를 밖으로 뺐습니다.
 const checkIsRecent = (dateString: string) => {
   const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000
   return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
 }
 
-// ✅ 2. UI 전용 타입: 기존 Notice 데이터에 프론트엔드에서 계산한 isRecent를 살짝 얹어줍니다.
+// 새 글(isRecent)'이라는 빨간색 N 스티커를 붙일지 말지 표시 
 type NoticeWithUI = Notice & { isRecent: boolean }
 
 export function NoticeSection() {
-  // state가 NoticeWithUI를 담도록 변경, now state는 완전히 삭제!
   const [notices, setNotices] = useState<NoticeWithUI[]>([])
   const [isLoading, setIsLoading] = useState(true)
 
@@ -37,11 +35,9 @@ export function NoticeSection() {
     async function fetchNotices() {
       setIsLoading(true)
 
-      // 웨이터(Action) 호출 (Action 안에 이미 try/catch가 있으므로 여기선 생략)
       const result = await getNoticesAction()
 
       if (result.success && result.data) {
-        // ✅ 3. 데이터 가공: 화면을 그리기 전에 미리 '새 글' 여부를 계산해서 데이터에 붙여버립니다.
         const processedNotices = result.data.map((item) => ({
           ...item,
           isRecent: checkIsRecent(item.createdAt),
@@ -52,7 +48,6 @@ export function NoticeSection() {
         setNotices([])
       }
 
-      // ✅ finally 역할을 하는 로직
       setIsLoading(false)
     }
 
@@ -87,7 +82,6 @@ export function NoticeSection() {
             </div>
           ) : notices.length > 0 ? (
             notices.map((item) => {
-              // ✅ 4. map 내부 가독성 개선: 계산 로직이 다 빠지고 UI 그리는 것에만 집중합니다!
               const config = NOTICE_CATEGORY_CONFIG[item.category] || NOTICE_CATEGORY_CONFIG.NOTICE
 
               return (
@@ -107,7 +101,6 @@ export function NoticeSection() {
                       <div className="flex min-w-0 items-center gap-1.5">
                         <p className="truncate text-sm font-medium">{item.title}</p>
 
-                        {/* 아까 가공해둔 isRecent를 꺼내서 쓰기만 하면 끝! */}
                         {item.isRecent && (
                           <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-500 text-[8px] font-bold text-white">
                             N
@@ -117,7 +110,6 @@ export function NoticeSection() {
                     </div>
 
                     <span className="text-muted-foreground shrink-0 text-xs">
-                      {/* 🍯 아까 말씀드린 예쁜 날짜 포맷 적용 */}
                       {formatDateDot(new Date(item.createdAt))}
                     </span>
                   </div>

--- a/src/featured/dashboard/components/NoticeSection.tsx
+++ b/src/featured/dashboard/components/NoticeSection.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react'
 import { getNoticesAction } from '../actions/dashboard.action'
 import type { Notice } from '@/featured/notice/types'
 import { NOTICE_CATEGORY_CONFIG } from '@/featured/notice/constants'
+import { formatDateDot } from '@/shared/lib/utils/date' // 🍯 날짜 포맷 꿀팁!
 
 const fadeUp = {
   hidden: { opacity: 0, y: 16 },
@@ -18,33 +19,45 @@ const fadeUp = {
   }),
 }
 
+// ✅ 1. 로직 분리: 새 글(72시간 이내)인지 확인하는 함수를 밖으로 뺐습니다.
+const checkIsRecent = (dateString: string) => {
+  const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000
+  return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
+}
+
+// ✅ 2. UI 전용 타입: 기존 Notice 데이터에 프론트엔드에서 계산한 isRecent를 살짝 얹어줍니다.
+type NoticeWithUI = Notice & { isRecent: boolean }
+
 export function NoticeSection() {
-  const [notices, setNotices] = useState<Notice[]>([])
+  // state가 NoticeWithUI를 담도록 변경, now state는 완전히 삭제!
+  const [notices, setNotices] = useState<NoticeWithUI[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [now, setNow] = useState<number>(0)
 
   useEffect(() => {
     async function fetchNotices() {
       setIsLoading(true)
 
-      // 웨이터가 주방(서버)에 다녀옵니다. (여기서 약간의 시간이 걸림)
+      // 웨이터(Action) 호출 (Action 안에 이미 try/catch가 있으므로 여기선 생략)
       const result = await getNoticesAction()
 
-      // [수정된 부분] 데이터가 도착한 직후에 시계를 보고 메모(now)합니다!
-      // 이렇게 서버 통신(비동기) 이후에 상태를 바꾸면, 리액트가 숨을 고를 수 있어서 에러가 안 납니다.
-      setNow(Date.now())
-
       if (result.success && result.data) {
-        setNotices(result.data)
+        // ✅ 3. 데이터 가공: 화면을 그리기 전에 미리 '새 글' 여부를 계산해서 데이터에 붙여버립니다.
+        const processedNotices = result.data.map((item) => ({
+          ...item,
+          isRecent: checkIsRecent(item.createdAt),
+        }))
+        setNotices(processedNotices)
       } else {
         console.error('공지사항 불러오기 실패:', result.message)
         setNotices([])
       }
+
+      // ✅ finally 역할을 하는 로직
       setIsLoading(false)
     }
 
     fetchNotices()
-  }, []) // 맨 위에 있던 setNow(Date.now())는 삭제했습니다!
+  }, [])
 
   return (
     <motion.div
@@ -74,11 +87,8 @@ export function NoticeSection() {
             </div>
           ) : notices.length > 0 ? (
             notices.map((item) => {
+              // ✅ 4. map 내부 가독성 개선: 계산 로직이 다 빠지고 UI 그리는 것에만 집중합니다!
               const config = NOTICE_CATEGORY_CONFIG[item.category] || NOTICE_CATEGORY_CONFIG.NOTICE
-
-              // 여기서 메모해둔 now 값을 씁니다.
-              const isRecent =
-                now > 0 && new Date(item.createdAt).getTime() > now - 3 * 24 * 60 * 60 * 1000
 
               return (
                 <Link
@@ -97,7 +107,8 @@ export function NoticeSection() {
                       <div className="flex min-w-0 items-center gap-1.5">
                         <p className="truncate text-sm font-medium">{item.title}</p>
 
-                        {isRecent && (
+                        {/* 아까 가공해둔 isRecent를 꺼내서 쓰기만 하면 끝! */}
+                        {item.isRecent && (
                           <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-500 text-[8px] font-bold text-white">
                             N
                           </span>
@@ -106,7 +117,8 @@ export function NoticeSection() {
                     </div>
 
                     <span className="text-muted-foreground shrink-0 text-xs">
-                      {item.createdAt.split('T')[0]}
+                      {/* 🍯 아까 말씀드린 예쁜 날짜 포맷 적용 */}
+                      {formatDateDot(new Date(item.createdAt))}
                     </span>
                   </div>
                 </Link>

--- a/src/featured/dashboard/components/NoticeSection.tsx
+++ b/src/featured/dashboard/components/NoticeSection.tsx
@@ -5,9 +5,9 @@ import { motion } from 'framer-motion'
 import { Card, CardContent } from '@/shared/ui/card'
 import { ChevronRight } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { getNoticesAction } from '../actions/dashboard.action'
+import { getNoticesAction } from '@/featured/notice/actions/notice.action'
 import type { Notice } from '@/featured/notice/types'
-import { NOTICE_CATEGORY_CONFIG } from '@/featured/notice/constants'
+import { NOTICE_CATEGORY } from '@/featured/notice/constants'
 import { formatDateDot } from '@/shared/lib/utils/date'
 
 const fadeUp = {
@@ -24,7 +24,6 @@ const checkIsRecent = (dateString: string) => {
   return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
 }
 
-// 새 글(isRecent)'이라는 빨간색 N 스티커를 붙일지 말지 표시 
 type NoticeWithUI = Notice & { isRecent: boolean }
 
 export function NoticeSection() {
@@ -35,20 +34,28 @@ export function NoticeSection() {
     async function fetchNotices() {
       setIsLoading(true)
 
-      const result = await getNoticesAction()
+      // [수정 2] action에서 던진 에러(throw)를 잡기 위해 try...catch 블록을 추가합니다.
+      try {
+        const result = await getNoticesAction()
 
-      if (result.success && result.data) {
-        const processedNotices = result.data.map((item) => ({
-          ...item,
-          isRecent: checkIsRecent(item.createdAt),
-        }))
-        setNotices(processedNotices)
-      } else {
-        console.error('공지사항 불러오기 실패:', result.message)
+        if (result.success && result.data) {
+          const processedNotices = result.data.map((item) => ({
+            ...item,
+            isRecent: checkIsRecent(item.createdAt),
+          }))
+          setNotices(processedNotices)
+        } else {
+          console.error('공지사항 불러오기 실패:', result.message)
+          setNotices([])
+        }
+      } catch (error) {
+        // 서버가 터지는 등 치명적인 에러가 발생했을 때 화면이 깨지지 않도록 방어합니다.
+        console.error('공지사항 통신 에러 발생:', error)
         setNotices([])
+      } finally {
+        // 성공하든 실패하든 마지막에 로딩 상태를 끝냅니다.
+        setIsLoading(false)
       }
-
-      setIsLoading(false)
     }
 
     fetchNotices()
@@ -82,7 +89,7 @@ export function NoticeSection() {
             </div>
           ) : notices.length > 0 ? (
             notices.map((item) => {
-              const config = NOTICE_CATEGORY_CONFIG[item.category] || NOTICE_CATEGORY_CONFIG.NOTICE
+              const config = NOTICE_CATEGORY[item.category] || NOTICE_CATEGORY.NOTICE
 
               return (
                 <Link

--- a/src/featured/notice/actions/notice.action.ts
+++ b/src/featured/notice/actions/notice.action.ts
@@ -1,0 +1,33 @@
+//이 파일에 있는 함수들은 무조건 백엔드(서버) 환경에서만 실행해!"라는 강력한 선언
+'use server'
+
+import type { ApiResponse } from '@/shared/lib/api'
+import type { Notice, NoticeDetailResponse } from '../types'
+import { getNotices, getNoticeDetail } from '../services/notice.service'
+import { isRedirectError } from 'next/dist/client/components/redirect-error'
+
+// 공지사항 목록 조회 Action
+export async function getNoticesAction(): Promise<ApiResponse<Notice[]>> {
+  try {
+    return await getNotices()
+  } catch (error) {
+    // Next.js의 redirect 에러인 경우 그대로 던져서 페이지 이동을 허용
+    // (isRedirectError(error)) throw error 구문으로 리다이렉트 에러는 건드리지 않고 통과시켜 주는 것
+    if (isRedirectError(error)) throw error
+
+    // 일반 에러도 그대로 던져서 클라이언트(UI)에서 처리하도록 함
+    throw error
+  }
+}
+
+// 공지사항 상세 조회 Action
+export async function getNoticeDetailAction(
+  id: number,
+): Promise<ApiResponse<NoticeDetailResponse>> {
+  try {
+    return await getNoticeDetail(id)
+  } catch (error) {
+    if (isRedirectError(error)) throw error
+    throw error
+  }
+}

--- a/src/featured/notice/components/NoticeClient.tsx
+++ b/src/featured/notice/components/NoticeClient.tsx
@@ -1,19 +1,15 @@
 'use client'
 
-// 1. Notice 타입을 가져옵니다.
 import type { Notice } from '@/featured/notice/types'
 import { useNoticeFilter } from '@/featured/notice/hooks/useNoticeFilter'
 import { NoticeFilters } from '@/featured/notice/components/NoticeFilters'
 import { NoticeList } from '@/featured/notice/components/NoticeList'
 
-// 2. 부모 컴포넌트(서버)로부터 어떤 데이터를 받을지 규칙(Props)을 정해줍니다.
 interface NoticeClientProps {
   initialNotices: Notice[]
 }
 
-// 3. 괄호 안에 { initialNotices }를 적어서 부모가 주는 진짜 데이터를 받습니다.
 export function NoticeClient({ initialNotices }: NoticeClientProps) {
-  // 4. 에러가 났던 빈 괄호 안에, 방금 받은 진짜 데이터(initialNotices)를 넣어줍니다!
   const { search, setSearch, category, setCategory, notices } = useNoticeFilter(initialNotices)
 
   return (

--- a/src/featured/notice/components/NoticeClient.tsx
+++ b/src/featured/notice/components/NoticeClient.tsx
@@ -1,11 +1,20 @@
 'use client'
 
+// 1. Notice 타입을 가져옵니다.
+import type { Notice } from '@/featured/notice/types'
 import { useNoticeFilter } from '@/featured/notice/hooks/useNoticeFilter'
 import { NoticeFilters } from '@/featured/notice/components/NoticeFilters'
 import { NoticeList } from '@/featured/notice/components/NoticeList'
 
-export function NoticeClient() {
-  const { search, setSearch, category, setCategory, notices } = useNoticeFilter()
+// 2. 부모 컴포넌트(서버)로부터 어떤 데이터를 받을지 규칙(Props)을 정해줍니다.
+interface NoticeClientProps {
+  initialNotices: Notice[]
+}
+
+// 3. 괄호 안에 { initialNotices }를 적어서 부모가 주는 진짜 데이터를 받습니다.
+export function NoticeClient({ initialNotices }: NoticeClientProps) {
+  // 4. 에러가 났던 빈 괄호 안에, 방금 받은 진짜 데이터(initialNotices)를 넣어줍니다!
+  const { search, setSearch, category, setCategory, notices } = useNoticeFilter(initialNotices)
 
   return (
     <div className="px-8 py-6">

--- a/src/featured/notice/components/NoticeDetail.tsx
+++ b/src/featured/notice/components/NoticeDetail.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent } from '@/shared/ui/card'
 import type { Notice, NoticeDetailResponse } from '@/featured/notice/types'
 import { NOTICE_CATEGORY } from '@/featured/notice/constants'
 import { formatDateDot } from '@/shared/lib/utils/date'
+import Image from 'next/image'
 
 interface NoticeDetailProps {
   notice: NoticeDetailResponse
@@ -138,7 +139,7 @@ export function NoticeDetail({ notice, prevNotice, nextNotice }: NoticeDetailPro
             <div className="mt-8 flex flex-col gap-4">
               {notice.imageUrls.map((url, index) => (
                 // eslint-disable-next-line @next/next/no-img-element
-                <img
+                <Image
                   key={index}
                   src={url}
                   alt={`공지사항 첨부 이미지 ${index + 1}`}

--- a/src/featured/notice/components/NoticeDetail.tsx
+++ b/src/featured/notice/components/NoticeDetail.tsx
@@ -5,22 +5,16 @@ import { ArrowLeft, Calendar, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from '@/shared/ui/button'
 import { Card, CardContent } from '@/shared/ui/card'
-
-// [수정 1] 컴포넌트 이름(NoticeDetail)과 타입 이름이 똑같아서 헷갈리므로, 타입의 이름을 'NoticeDetailData'로 살짝 바꿔서 부릅니다.
 import type { Notice, NoticeDetailResponse } from '@/featured/notice/types'
-// [수정 2] 가짜 색상표 대신, 우리가 만든 진짜 꾸미기 사전(config)을 가져옵니다.
 import { NOTICE_CATEGORY } from '@/featured/notice/constants'
-// [수정 3] 서버의 못생긴 날짜를 예쁘게 다듬을 가위(함수)를 가져옵니다.
 import { formatDateDot } from '@/shared/lib/utils/date'
 
-// [수정 4] 부모가 주는 상세 데이터의 타입을 새로운 'NoticeDetailData'로 지정합니다.
 interface NoticeDetailProps {
   notice: NoticeDetailResponse
   prevNotice: Notice | null
   nextNotice: Notice | null
 }
 
-// 본문을 그려주는 함수 (이 부분은 기존 로직이 아주 훌륭해서 그대로 둡니다!)
 function NoticeContent({ content }: { content: string }) {
   const paragraphs = content.split('\n\n')
 
@@ -72,7 +66,6 @@ function NoticeContent({ content }: { content: string }) {
   )
 }
 
-// [수정 5] 서버는 '새 글'인지 안 알려주므로, 리스트에서 썼던 계산기를 똑같이 가져옵니다.
 const checkIsRecent = (dateString: string) => {
   const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000 // 3일 치 시간
   return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
@@ -80,8 +73,6 @@ const checkIsRecent = (dateString: string) => {
 
 export function NoticeDetail({ notice, prevNotice, nextNotice }: NoticeDetailProps) {
   const shouldReduceMotion = useReducedMotion()
-
-  // [수정 6] 영어 카테고리를 한글과 색상으로 통역해 주는 사전(config)을 씁니다.
   const config = NOTICE_CATEGORY[notice.category] || NOTICE_CATEGORY.NOTICE
   const isRecent = checkIsRecent(notice.createdAt)
 
@@ -118,7 +109,6 @@ export function NoticeDetail({ notice, prevNotice, nextNotice }: NoticeDetailPro
         {/* 카드 헤더 */}
         <div className="border-border/50 border-b px-8 py-6">
           <div className="mb-3 flex items-center gap-2">
-            {/* [수정 7] config 사전에서 한글 이름(label)과 색상(color)을 꺼내서 씁니다! */}
             <span
               className={`flex h-5 w-14 shrink-0 items-center justify-center rounded text-[10px] font-medium ${config.color}`}
             >
@@ -135,7 +125,6 @@ export function NoticeDetail({ notice, prevNotice, nextNotice }: NoticeDetailPro
 
           <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
             <Calendar className="h-3 w-3" />
-            {/* [수정 8] 가짜 date 대신 서버의 createdAt을 예쁘게 포장해서 씁니다. */}
             <span>{formatDateDot(new Date(notice.createdAt))}</span>
           </div>
         </div>
@@ -145,7 +134,6 @@ export function NoticeDetail({ notice, prevNotice, nextNotice }: NoticeDetailPro
           {/* 글씨 본문 */}
           <NoticeContent content={notice.content} />
 
-          {/* [수정 9] 새 API에 추가된 '첨부 이미지(imageUrls)'를 그리는 화면을 추가했습니다! */}
           {notice.imageUrls && notice.imageUrls.length > 0 && (
             <div className="mt-8 flex flex-col gap-4">
               {notice.imageUrls.map((url, index) => (
@@ -162,7 +150,7 @@ export function NoticeDetail({ notice, prevNotice, nextNotice }: NoticeDetailPro
         </CardContent>
       </Card>
 
-      {/* [보너스 수정] 기껏 받아온 이전글/다음글(prevNotice, nextNotice)을 화면 밑에 예쁘게 달아주면 좋습니다! (선택 사항) */}
+      {/*  이전글/다음글(prevNotice, nextNotice) 추가? */}
     </motion.div>
   )
 }

--- a/src/featured/notice/components/NoticeDetail.tsx
+++ b/src/featured/notice/components/NoticeDetail.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/shared/ui/button'
 import { Card, CardContent } from '@/shared/ui/card'
 import type { Notice, NoticeDetailResponse } from '@/featured/notice/types'
 import { NOTICE_CATEGORY } from '@/featured/notice/constants'
-import { formatDateDot } from '@/shared/lib/utils/date'
+import { formatDateDot, checkIsRecent } from '@/shared/lib/utils/date'
 import Image from 'next/image'
 
 interface NoticeDetailProps {
@@ -67,10 +67,6 @@ function NoticeContent({ content }: { content: string }) {
   )
 }
 
-const checkIsRecent = (dateString: string) => {
-  const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000 // 3일 치 시간
-  return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
-}
 
 export function NoticeDetail({ notice, prevNotice, nextNotice }: NoticeDetailProps) {
   const shouldReduceMotion = useReducedMotion()

--- a/src/featured/notice/components/NoticeDetail.tsx
+++ b/src/featured/notice/components/NoticeDetail.tsx
@@ -6,15 +6,21 @@ import Link from 'next/link'
 import { Button } from '@/shared/ui/button'
 import { Card, CardContent } from '@/shared/ui/card'
 
-import type { Notice } from '@/featured/notice/types'
-import { CATEGORY_COLORS } from '@/featured/notice/types'
+// [수정 1] 컴포넌트 이름(NoticeDetail)과 타입 이름이 똑같아서 헷갈리므로, 타입의 이름을 'NoticeDetailData'로 살짝 바꿔서 부릅니다.
+import type { Notice, NoticeDetailResponse } from '@/featured/notice/types'
+// [수정 2] 가짜 색상표 대신, 우리가 만든 진짜 꾸미기 사전(config)을 가져옵니다.
+import { NOTICE_CATEGORY } from '@/featured/notice/constants'
+// [수정 3] 서버의 못생긴 날짜를 예쁘게 다듬을 가위(함수)를 가져옵니다.
+import { formatDateDot } from '@/shared/lib/utils/date'
 
+// [수정 4] 부모가 주는 상세 데이터의 타입을 새로운 'NoticeDetailData'로 지정합니다.
 interface NoticeDetailProps {
-  notice: Notice
+  notice: NoticeDetailResponse
   prevNotice: Notice | null
   nextNotice: Notice | null
 }
 
+// 본문을 그려주는 함수 (이 부분은 기존 로직이 아주 훌륭해서 그대로 둡니다!)
 function NoticeContent({ content }: { content: string }) {
   const paragraphs = content.split('\n\n')
 
@@ -66,8 +72,18 @@ function NoticeContent({ content }: { content: string }) {
   )
 }
 
+// [수정 5] 서버는 '새 글'인지 안 알려주므로, 리스트에서 썼던 계산기를 똑같이 가져옵니다.
+const checkIsRecent = (dateString: string) => {
+  const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000 // 3일 치 시간
+  return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
+}
+
 export function NoticeDetail({ notice, prevNotice, nextNotice }: NoticeDetailProps) {
   const shouldReduceMotion = useReducedMotion()
+
+  // [수정 6] 영어 카테고리를 한글과 색상으로 통역해 주는 사전(config)을 씁니다.
+  const config = NOTICE_CATEGORY[notice.category] || NOTICE_CATEGORY.NOTICE
+  const isRecent = checkIsRecent(notice.createdAt)
 
   return (
     <motion.div
@@ -102,12 +118,13 @@ export function NoticeDetail({ notice, prevNotice, nextNotice }: NoticeDetailPro
         {/* 카드 헤더 */}
         <div className="border-border/50 border-b px-8 py-6">
           <div className="mb-3 flex items-center gap-2">
+            {/* [수정 7] config 사전에서 한글 이름(label)과 색상(color)을 꺼내서 씁니다! */}
             <span
-              className={`flex h-5 w-14 shrink-0 items-center justify-center rounded text-[10px] font-medium ${CATEGORY_COLORS[notice.category]}`}
+              className={`flex h-5 w-14 shrink-0 items-center justify-center rounded text-[10px] font-medium ${config.color}`}
             >
-              {notice.category}
+              {config.label}
             </span>
-            {notice.isNew ? (
+            {isRecent ? (
               <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-500 text-[8px] font-bold text-white">
                 N
               </span>
@@ -118,15 +135,34 @@ export function NoticeDetail({ notice, prevNotice, nextNotice }: NoticeDetailPro
 
           <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
             <Calendar className="h-3 w-3" />
-            <span>{notice.date}</span>
+            {/* [수정 8] 가짜 date 대신 서버의 createdAt을 예쁘게 포장해서 씁니다. */}
+            <span>{formatDateDot(new Date(notice.createdAt))}</span>
           </div>
         </div>
 
-        {/* 본문 */}
+        {/* 본문 내용 + 첨부 이미지 */}
         <CardContent className="px-8 py-7">
+          {/* 글씨 본문 */}
           <NoticeContent content={notice.content} />
+
+          {/* [수정 9] 새 API에 추가된 '첨부 이미지(imageUrls)'를 그리는 화면을 추가했습니다! */}
+          {notice.imageUrls && notice.imageUrls.length > 0 && (
+            <div className="mt-8 flex flex-col gap-4">
+              {notice.imageUrls.map((url, index) => (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  key={index}
+                  src={url}
+                  alt={`공지사항 첨부 이미지 ${index + 1}`}
+                  className="w-full max-w-2xl rounded-lg border"
+                />
+              ))}
+            </div>
+          )}
         </CardContent>
       </Card>
+
+      {/* [보너스 수정] 기껏 받아온 이전글/다음글(prevNotice, nextNotice)을 화면 밑에 예쁘게 달아주면 좋습니다! (선택 사항) */}
     </motion.div>
   )
 }

--- a/src/featured/notice/components/NoticeFilters.tsx
+++ b/src/featured/notice/components/NoticeFilters.tsx
@@ -4,7 +4,7 @@ import { Search } from 'lucide-react'
 import { Input } from '@/shared/ui/input'
 import { Button } from '@/shared/ui/button'
 import type { FilterCategory } from '@/featured/notice/types'
-import { FILTER_CATEGORIES } from '@/featured/notice/types'
+import { NOTICE_CATEGORY, FILTER_CATEGORIES } from '@/featured/notice/constants'
 
 interface NoticeFiltersProps {
   search: string
@@ -12,6 +12,8 @@ interface NoticeFiltersProps {
   category: FilterCategory
   onCategoryChange: (value: FilterCategory) => void
 }
+
+// 2. 파일 안에 있던 const FILTER_CATEGORIES 배열은 깔끔하게 삭제했습니다. (상수로 뺐으니까요!)
 
 export function NoticeFilters({
   search,
@@ -22,17 +24,23 @@ export function NoticeFilters({
   return (
     <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex flex-wrap gap-1.5">
-        {FILTER_CATEGORIES.map((c) => (
-          <Button
-            key={c}
-            variant={category === c ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => onCategoryChange(c)}
-            className="h-7 px-3 text-xs"
-          >
-            {c}
-          </Button>
-        ))}
+        {/* 3. 위에서 import 해온 FILTER_CATEGORIES 상수를 사용해서 그립니다. */}
+        {FILTER_CATEGORIES.map((c) => {
+          // c가 'ALL'이면 '전체'라고 적고, 아니면 NOTICE_CATEGORY 사전에서 한글 라벨을 찾아옵니다.
+          const label = c === 'ALL' ? '전체' : NOTICE_CATEGORY[c]?.label
+
+          return (
+            <Button
+              key={c}
+              variant={category === c ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => onCategoryChange(c)}
+              className="h-7 px-3 text-xs"
+            >
+              {label}
+            </Button>
+          )
+        })}
       </div>
 
       <div className="relative w-full sm:w-96">

--- a/src/featured/notice/components/NoticeFilters.tsx
+++ b/src/featured/notice/components/NoticeFilters.tsx
@@ -13,8 +13,6 @@ interface NoticeFiltersProps {
   onCategoryChange: (value: FilterCategory) => void
 }
 
-// 2. 파일 안에 있던 const FILTER_CATEGORIES 배열은 깔끔하게 삭제했습니다. (상수로 뺐으니까요!)
-
 export function NoticeFilters({
   search,
   onSearchChange,
@@ -24,9 +22,7 @@ export function NoticeFilters({
   return (
     <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex flex-wrap gap-1.5">
-        {/* 3. 위에서 import 해온 FILTER_CATEGORIES 상수를 사용해서 그립니다. */}
         {FILTER_CATEGORIES.map((c) => {
-          // c가 'ALL'이면 '전체'라고 적고, 아니면 NOTICE_CATEGORY 사전에서 한글 라벨을 찾아옵니다.
           const label = c === 'ALL' ? '전체' : NOTICE_CATEGORY[c]?.label
 
           return (

--- a/src/featured/notice/components/NoticeList.tsx
+++ b/src/featured/notice/components/NoticeList.tsx
@@ -5,17 +5,28 @@ import { Bell } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { Card, CardContent } from '@/shared/ui/card'
 import type { Notice } from '@/featured/notice/types'
-import { CATEGORY_COLORS } from '@/featured/notice/types'
+
+// [수정 포인트 1] 예전 가짜 색상표 지우고, 우리가 만든 진짜 사전(constants)을 가져옵니다.
+import { NOTICE_CATEGORY } from '@/featured/notice/constants'
+// [수정 포인트 2] 서버가 준 날짜 모양을 예쁘게 깎아줄 도구를 가져옵니다.
+import { formatDateDot } from '@/shared/lib/utils/date'
 
 interface NoticeListProps {
   notices: Notice[]
   search: string
 }
 
+// [수정 포인트 3] 서버는 '새 글'인지 안 알려줍니다. 우리가 날짜를 보고 직접 판단하는 계산기를 만듭니다.
+const checkIsRecent = (dateString: string) => {
+  const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000 // 3일 치 시간
+  return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
+}
+
 export function NoticeList({ notices, search }: NoticeListProps) {
   const router = useRouter()
   const shouldReduceMotion = useReducedMotion()
 
+  // 데이터가 없을 때 빈 화면 보여주는 부분 (수정할 필요 없이 완벽합니다!)
   if (notices.length === 0) {
     return (
       <motion.div
@@ -41,37 +52,52 @@ export function NoticeList({ notices, search }: NoticeListProps) {
     <Card className="border-border/50 overflow-hidden py-4">
       <CardContent className="p-0">
         <AnimatePresence initial={false}>
-          {notices.map((notice, i) => (
-            <motion.div
-              key={notice.id}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={
-                shouldReduceMotion ? { duration: 0 } : { delay: i * 0.02, duration: 0.15 }
-              }
-              whileTap={shouldReduceMotion ? {} : { opacity: 0.6, transition: { duration: 0.05 } }}
-              onClick={() => router.push(`/notices/${notice.id}`)}
-              className="border-border/40 hover:bg-muted/40 flex cursor-pointer items-center justify-between gap-4 border-b px-6 py-4 transition-colors last:border-b-0"
-            >
-              <div className="flex min-w-0 flex-1 items-center gap-3">
-                <span
-                  className={`flex h-5 w-14 shrink-0 items-center justify-center rounded text-[10px] font-medium ${CATEGORY_COLORS[notice.category]}`}
-                >
-                  {notice.category}
-                </span>
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <p className="truncate text-sm font-medium">{notice.title}</p>
-                  {notice.isNew ? (
-                    <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full bg-red-500 text-[8px] font-bold text-white">
-                      N
-                    </span>
-                  ) : null}
+          {notices.map((notice, i) => {
+            // [핵심 변경] 화면을 그리기 전에, 여기서 영어(notice.category)를 한글과 색상으로 번역합니다.
+            const config = NOTICE_CATEGORY[notice.category] || NOTICE_CATEGORY.NOTICE
+            // 이 글이 최근 3일 안에 써진 건지 검사합니다.
+            const isRecent = checkIsRecent(notice.createdAt)
+
+            return (
+              <motion.div
+                key={notice.id}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={
+                  shouldReduceMotion ? { duration: 0 } : { delay: i * 0.02, duration: 0.15 }
+                }
+                whileTap={
+                  shouldReduceMotion ? {} : { opacity: 0.6, transition: { duration: 0.05 } }
+                }
+                // 클릭하면 그 공지사항의 상세 페이지로 이동!
+                onClick={() => router.push(`/notices/${notice.id}`)}
+                className="border-border/40 hover:bg-muted/40 flex cursor-pointer items-center justify-between gap-4 border-b px-6 py-4 transition-colors last:border-b-0"
+              >
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  {/* 번역기(config)에서 색상(color)과 한글 이름(label)을 쏙 빼서 씁니다 */}
+                  <span
+                    className={`flex h-5 w-14 shrink-0 items-center justify-center rounded text-[10px] font-medium ${config.color}`}
+                  >
+                    {config.label}
+                  </span>
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <p className="truncate text-sm font-medium">{notice.title}</p>
+                    {/* isRecent가 진짜(true)일 때만 빨간색 N 마크를 띄워줍니다 */}
+                    {isRecent ? (
+                      <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full bg-red-500 text-[8px] font-bold text-white">
+                        N
+                      </span>
+                    ) : null}
+                  </div>
                 </div>
-              </div>
-              <span className="text-muted-foreground shrink-0 text-xs">{notice.date}</span>
-            </motion.div>
-          ))}
+                {/* 예전의 가짜 date 대신, 진짜 createdAt을 넣고 예쁘게 깎아줍니다. */}
+                <span className="text-muted-foreground shrink-0 text-xs">
+                  {formatDateDot(new Date(notice.createdAt))}
+                </span>
+              </motion.div>
+            )
+          })}
         </AnimatePresence>
       </CardContent>
     </Card>

--- a/src/featured/notice/components/NoticeList.tsx
+++ b/src/featured/notice/components/NoticeList.tsx
@@ -6,17 +6,13 @@ import { useRouter } from 'next/navigation'
 import { Card, CardContent } from '@/shared/ui/card'
 import type { Notice } from '@/featured/notice/types'
 import { NOTICE_CATEGORY } from '@/featured/notice/constants'
-import { formatDateDot } from '@/shared/lib/utils/date'
+import { formatDateDot, checkIsRecent } from '@/shared/lib/utils/date'
 
 interface NoticeListProps {
   notices: Notice[]
   search: string
 }
 
-const checkIsRecent = (dateString: string) => {
-  const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000 // 3일 치 시간
-  return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
-}
 
 export function NoticeList({ notices, search }: NoticeListProps) {
   const router = useRouter()

--- a/src/featured/notice/components/NoticeList.tsx
+++ b/src/featured/notice/components/NoticeList.tsx
@@ -5,10 +5,7 @@ import { Bell } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { Card, CardContent } from '@/shared/ui/card'
 import type { Notice } from '@/featured/notice/types'
-
-// [수정 포인트 1] 예전 가짜 색상표 지우고, 우리가 만든 진짜 사전(constants)을 가져옵니다.
 import { NOTICE_CATEGORY } from '@/featured/notice/constants'
-// [수정 포인트 2] 서버가 준 날짜 모양을 예쁘게 깎아줄 도구를 가져옵니다.
 import { formatDateDot } from '@/shared/lib/utils/date'
 
 interface NoticeListProps {
@@ -16,7 +13,6 @@ interface NoticeListProps {
   search: string
 }
 
-// [수정 포인트 3] 서버는 '새 글'인지 안 알려줍니다. 우리가 날짜를 보고 직접 판단하는 계산기를 만듭니다.
 const checkIsRecent = (dateString: string) => {
   const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000 // 3일 치 시간
   return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
@@ -26,7 +22,6 @@ export function NoticeList({ notices, search }: NoticeListProps) {
   const router = useRouter()
   const shouldReduceMotion = useReducedMotion()
 
-  // 데이터가 없을 때 빈 화면 보여주는 부분 (수정할 필요 없이 완벽합니다!)
   if (notices.length === 0) {
     return (
       <motion.div
@@ -53,9 +48,7 @@ export function NoticeList({ notices, search }: NoticeListProps) {
       <CardContent className="p-0">
         <AnimatePresence initial={false}>
           {notices.map((notice, i) => {
-            // [핵심 변경] 화면을 그리기 전에, 여기서 영어(notice.category)를 한글과 색상으로 번역합니다.
             const config = NOTICE_CATEGORY[notice.category] || NOTICE_CATEGORY.NOTICE
-            // 이 글이 최근 3일 안에 써진 건지 검사합니다.
             const isRecent = checkIsRecent(notice.createdAt)
 
             return (
@@ -75,7 +68,6 @@ export function NoticeList({ notices, search }: NoticeListProps) {
                 className="border-border/40 hover:bg-muted/40 flex cursor-pointer items-center justify-between gap-4 border-b px-6 py-4 transition-colors last:border-b-0"
               >
                 <div className="flex min-w-0 flex-1 items-center gap-3">
-                  {/* 번역기(config)에서 색상(color)과 한글 이름(label)을 쏙 빼서 씁니다 */}
                   <span
                     className={`flex h-5 w-14 shrink-0 items-center justify-center rounded text-[10px] font-medium ${config.color}`}
                   >
@@ -83,7 +75,6 @@ export function NoticeList({ notices, search }: NoticeListProps) {
                   </span>
                   <div className="flex min-w-0 items-center gap-1.5">
                     <p className="truncate text-sm font-medium">{notice.title}</p>
-                    {/* isRecent가 진짜(true)일 때만 빨간색 N 마크를 띄워줍니다 */}
                     {isRecent ? (
                       <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full bg-red-500 text-[8px] font-bold text-white">
                         N
@@ -91,7 +82,6 @@ export function NoticeList({ notices, search }: NoticeListProps) {
                     ) : null}
                   </div>
                 </div>
-                {/* 예전의 가짜 date 대신, 진짜 createdAt을 넣고 예쁘게 깎아줍니다. */}
                 <span className="text-muted-foreground shrink-0 text-xs">
                   {formatDateDot(new Date(notice.createdAt))}
                 </span>

--- a/src/featured/notice/constants.ts
+++ b/src/featured/notice/constants.ts
@@ -26,8 +26,7 @@ const NOTICE_CATEGORY: Record<NoticeCategory, { label: string; color: string }> 
 
 // const NOTICE_PAGE_SIZE = 10;
 
-// 화면에 그릴 필터 버튼 목록 (이것도 상수로 관리!)
-// ❌ export 제거!
+// 카테고리 필터
 const FILTER_CATEGORIES: FilterCategory[] = [
   'ALL',
   'NOTICE',
@@ -37,5 +36,4 @@ const FILTER_CATEGORIES: FilterCategory[] = [
   'MAINTENANCE',
 ]
 
-// 여기서 한 번에 깔끔하게 내보냅니다.
 export { NOTICE_CATEGORY, FILTER_CATEGORIES }

--- a/src/featured/notice/constants.ts
+++ b/src/featured/notice/constants.ts
@@ -1,6 +1,7 @@
-import type { NoticeCategory } from './types'
+import type { NoticeCategory, FilterCategory } from './types'
 
-const NOTICE_CATEGORY_CONFIG: Record<NoticeCategory, { label: string; color: string }> = {
+// 카테고리 설정값 모음
+const NOTICE_CATEGORY: Record<NoticeCategory, { label: string; color: string }> = {
   NOTICE: {
     label: '공지',
     color: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
@@ -25,7 +26,16 @@ const NOTICE_CATEGORY_CONFIG: Record<NoticeCategory, { label: string; color: str
 
 // const NOTICE_PAGE_SIZE = 10;
 
-export {
-  NOTICE_CATEGORY_CONFIG,
-  // NOTICE_PAGE_SIZE,
-}
+// 화면에 그릴 필터 버튼 목록 (이것도 상수로 관리!)
+// ❌ export 제거!
+const FILTER_CATEGORIES: FilterCategory[] = [
+  'ALL',
+  'NOTICE',
+  'UPDATE',
+  'GUIDE',
+  'EVENT',
+  'MAINTENANCE',
+]
+
+// 여기서 한 번에 깔끔하게 내보냅니다.
+export { NOTICE_CATEGORY, FILTER_CATEGORIES }

--- a/src/featured/notice/hooks/useNoticeFilter.ts
+++ b/src/featured/notice/hooks/useNoticeFilter.ts
@@ -1,14 +1,17 @@
-'use client'
-
+// src/featured/notice/hooks/useNoticeFilter.ts
 import { useRef, useState } from 'react'
-import type { FilterCategory } from '@/featured/notice/types'
-import { MOCK_NOTICES } from '@/featured/notice/types'
+// MOCK_NOTICES는 지우고, 진짜 타입인 Notice를 가져옵니다.
+import type { FilterCategory, Notice } from '@/featured/notice/types'
 import { debounce } from '@/shared/lib/utils/debounce'
 
-export function useNoticeFilter() {
+// 이제 이 훅은 "서버에서 가져온 진짜 공지사항 목록(initialNotices)"을 재료로 받습니다.
+export function useNoticeFilter(initialNotices: Notice[]) {
   const [search, setSearch] = useState('')
+  // 성능 최적화
   const [debouncedSearch, setDebouncedSearch] = useState('')
-  const [category, setCategory] = useState<FilterCategory>('전체')
+
+  // [수정 포인트 1] '전체'라는 한글 대신, types.ts에 정의된 'ALL'을 기본값으로 씁니다.
+  const [category, setCategory] = useState<FilterCategory>('ALL')
 
   const debouncedSetSearch = useRef(debounce(setDebouncedSearch, 300)).current
 
@@ -21,8 +24,10 @@ export function useNoticeFilter() {
     }
   }
 
-  const notices = MOCK_NOTICES.filter((n) => {
-    const matchesCategory = category === '전체' || n.category === category
+  // [수정 포인트 2] 가짜 데이터(MOCK_NOTICES) 대신, 인자로 받은 진짜 데이터(initialNotices)를 필터링합니다.
+  const notices = initialNotices.filter((n) => {
+    // 여기도 '전체' 대신 'ALL'로 비교합니다.
+    const matchesCategory = category === 'ALL' || n.category === category
     const matchesSearch = n.title.includes(debouncedSearch)
     return matchesCategory && matchesSearch
   })

--- a/src/featured/notice/hooks/useNoticeFilter.ts
+++ b/src/featured/notice/hooks/useNoticeFilter.ts
@@ -1,18 +1,12 @@
-// src/featured/notice/hooks/useNoticeFilter.ts
 import { useRef, useState } from 'react'
-// MOCK_NOTICES는 지우고, 진짜 타입인 Notice를 가져옵니다.
 import type { FilterCategory, Notice } from '@/featured/notice/types'
 import { debounce } from '@/shared/lib/utils/debounce'
 
-// 이제 이 훅은 "서버에서 가져온 진짜 공지사항 목록(initialNotices)"을 재료로 받습니다.
 export function useNoticeFilter(initialNotices: Notice[]) {
   const [search, setSearch] = useState('')
   // 성능 최적화
   const [debouncedSearch, setDebouncedSearch] = useState('')
-
-  // [수정 포인트 1] '전체'라는 한글 대신, types.ts에 정의된 'ALL'을 기본값으로 씁니다.
   const [category, setCategory] = useState<FilterCategory>('ALL')
-
   const debouncedSetSearch = useRef(debounce(setDebouncedSearch, 300)).current
 
   function handleSearchChange(value: string) {
@@ -24,9 +18,7 @@ export function useNoticeFilter(initialNotices: Notice[]) {
     }
   }
 
-  // [수정 포인트 2] 가짜 데이터(MOCK_NOTICES) 대신, 인자로 받은 진짜 데이터(initialNotices)를 필터링합니다.
   const notices = initialNotices.filter((n) => {
-    // 여기도 '전체' 대신 'ALL'로 비교합니다.
     const matchesCategory = category === 'ALL' || n.category === category
     const matchesSearch = n.title.includes(debouncedSearch)
     return matchesCategory && matchesSearch

--- a/src/featured/notice/services/notice.service.ts
+++ b/src/featured/notice/services/notice.service.ts
@@ -1,0 +1,12 @@
+import { ApiResponse, serverApi } from '@/shared/lib/api'
+import type { Notice, NoticeDetailResponse } from '../types'
+
+// 1. 공지사항 목록 조회
+export async function getNotices(): Promise<ApiResponse<Notice[]>> {
+  return await serverApi.get<Notice[]>('/api/v1/notices')
+}
+
+// 2. 공지사항 상세 조회
+export async function getNoticeDetail(id: number): Promise<ApiResponse<NoticeDetailResponse>> {
+  return await serverApi.get<NoticeDetailResponse>(`/api/v1/notices/${id}`)
+}

--- a/src/featured/notice/types.ts
+++ b/src/featured/notice/types.ts
@@ -1,7 +1,7 @@
 // 1. API 명세에 맞춘 카테고리
 export type NoticeCategory = 'NOTICE' | 'UPDATE' | 'GUIDE' | 'EVENT' | 'MAINTENANCE'
 
-//  필터용 카테고리
+// 필터용 카테고리
 export type FilterCategory = 'ALL' | NoticeCategory
 
 // 2. 공지사항 목록 타입
@@ -9,11 +9,11 @@ export interface Notice {
   id: number
   category: NoticeCategory
   title: string
-  createdAt: string // (기존 목업의 date 대신 API 명세인 createdAt 사용)
+  createdAt: string
 }
 
 // 3. 공지사항 상세 타입
-export interface NoticeDetail {
+export interface NoticeDetailResponse {
   id: number
   category: NoticeCategory
   title: string

--- a/src/featured/notice/types.ts
+++ b/src/featured/notice/types.ts
@@ -1,10 +1,10 @@
-// 1. API 명세에 맞춘 카테고리
+// API 명세에 맞춘 카테고리
 export type NoticeCategory = 'NOTICE' | 'UPDATE' | 'GUIDE' | 'EVENT' | 'MAINTENANCE'
 
 // 필터용 카테고리
 export type FilterCategory = 'ALL' | NoticeCategory
 
-// 2. 공지사항 목록 타입
+// 공지사항 목록 타입
 export interface Notice {
   id: number
   category: NoticeCategory
@@ -12,7 +12,7 @@ export interface Notice {
   createdAt: string
 }
 
-// 3. 공지사항 상세 타입
+// 공지사항 상세 타입
 export interface NoticeDetailResponse {
   id: number
   category: NoticeCategory

--- a/src/shared/lib/api/serverApi.ts
+++ b/src/shared/lib/api/serverApi.ts
@@ -87,6 +87,11 @@ async function tryRefresh(
  *
  * 에러 발생 시 throw — 호출 측에서 try/catch 사용.
  */
+
+
+// 현재 프로젝트의 serverApi.ts 코드를 자세히 보면, serverFetch 함수가 결과를 반환할 때 이미 Promise<ApiResponse<T>> 형태로 감싸서 주고 있습니다.
+// 즉, serverApi.get을 호출할 때는 실제 핵심 데이터(Notice[])만 제네릭(<>)으로 넘겨주면, serverApi 내부에서 알아서 ApiResponse 껍데기를 씌워서 반환해 줍니다.
+
 async function serverFetch<T>(
   method: string,
   endpoint: string,
@@ -174,3 +179,4 @@ export const serverApi = {
   delete: <T>(endpoint: string, config?: RequestConfig) =>
     serverFetch<T>('DELETE', endpoint, undefined, config),
 }
+

--- a/src/shared/lib/utils/date.ts
+++ b/src/shared/lib/utils/date.ts
@@ -54,3 +54,13 @@ export const addDays = (dateObj: Date, n: number): Date => {
   d.setDate(d.getDate() + n)
   return d
 }
+
+/**
+ * 주어진 날짜 문자열이 현재로부터 3일 이내인지 확인합니다.
+ * @param dateString ISO 형식의 날짜 문자열
+ * @returns 3일 이내이면 true
+ */
+export const checkIsRecent = (dateString: string): boolean => {
+  const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000
+  return new Date(dateString).getTime() > Date.now() - THREE_DAYS_MS
+}


### PR DESCRIPTION
## 변경 사항

- 공지사항 API 연동 작업 진행
- 공지사항 데이터를 서버에서 가져오도록 action 연결
- `useNoticeFilter` 훅에서 공지사항 카테고리(전체 / 업데이트 / 안내 등) 필터링 로직 구현
- `NoticeFilters` 컴포넌트에서 필터 버튼과 훅 상태 연결
- `NoticeList` 컴포넌트에서 필터링된 공지사항 목록 렌더링
- 공지사항 데이터 타입 정리 및 API 응답 구조에 맞게 타입 적용

## 리뷰 필요

- notice폴더 관련 모든 파일 

close #110 
