### PR TITLE
feat: 답변 제출 후 분석 사이클

### DIFF
--- a/src/featured/interview/actions/interview.action.ts
+++ b/src/featured/interview/actions/interview.action.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import type { ApiResponse } from '@/shared/lib/api'
+import { ApiResponse } from '@/shared/lib/api'
 import {
   CompleteFileUploadResponse,
   CreateInterviewResponse,
@@ -9,15 +9,23 @@ import {
   IssuePresignedUrlRequest,
   IssuePresignedUrlResponse,
   UpdateInterviewTitleResponse,
+  IssueVideoPresignedUrlRequest,
+  VideoInfo,
+  CompleteVideoFileUploadResponse,
+  IssueVideoPresignedUrlResponse,
+  AnswerAnalysisResponse,
 } from '../types'
 import {
   completeFileUpload,
+  completeVideoFileUpload,
   createInterview,
   finishInterview,
   generateInterviewQuestion,
   getInterviewQuestions,
   issuePresignedUrl,
+  issueVideoPresignedUrl,
   pauseInterview,
+  requestAnswerAnalysis,
   resumeInterview,
   startInterview,
   updateInterviewTitle,
@@ -73,6 +81,29 @@ export async function getInterviewQuestionsAction(
   intvId: number,
 ): Promise<ApiResponse<GetInterviewQuestionsResponse>> {
   return getInterviewQuestions(intvId)
+}
+
+// 답변 영상 업로드 presignedUrl 발급
+export async function issueVideoPresignedUrlAction(
+  questionSetId: number,
+  { video }: { video: IssueVideoPresignedUrlRequest },
+): Promise<ApiResponse<IssueVideoPresignedUrlResponse>> {
+  return issueVideoPresignedUrl(questionSetId, video)
+}
+
+// 답변 영상 업로드 완료
+export async function completeVideoFileUploadAction(
+  questionSetId: number,
+  video: VideoInfo,
+): Promise<ApiResponse<CompleteVideoFileUploadResponse>> {
+  return completeVideoFileUpload(questionSetId, video)
+}
+
+// 답변 분석 요청
+export async function requestAnswerAnalysisAction(
+  answerId: number,
+): Promise<ApiResponse<AnswerAnalysisResponse>> {
+  return requestAnswerAnalysis(answerId)
 }
 
 // 면접 시작

--- a/src/featured/interview/components/InterviewContainer.tsx
+++ b/src/featured/interview/components/InterviewContainer.tsx
@@ -23,6 +23,7 @@ export function InterviewContainer({ session, interviewId }: InterviewPageProps)
       />
       <QuestionBanner
         currentQuestion={session.currentQuestion}
+        questions={session.interviewQuestions}
         isActive={session.isActive}
         typingKey={session.typingKey}
         questionRevealed={session.questionRevealed}
@@ -48,6 +49,7 @@ export function InterviewContainer({ session, interviewId }: InterviewPageProps)
         cameraOn={session.cameraOn}
         phase={session.phase}
         currentQuestion={session.currentQuestion}
+        questionCount={session.interviewQuestions.length}
         onToggleMic={() => session.setMicOn((v) => !v)}
         onToggleCamera={() => session.setCameraOn((v) => !v)}
         onStartInterview={session.startInterview}

--- a/src/featured/interview/components/InterviewSetupModal.tsx
+++ b/src/featured/interview/components/InterviewSetupModal.tsx
@@ -145,9 +145,9 @@ export function InterviewSetupModal({ session, isResume = false }: InterviewSetu
         throw new Error('업로드할 파일이 없습니다.')
       }
 
-      const finalRes = await completeFileUploadAction(interviewId, { files: uploadedFiles })
-      if (!finalRes.success) {
-        throw new Error(finalRes.message || '파일 업로드 완료 처리 실패')
+      const completeRes = await completeFileUploadAction(interviewId, { files: uploadedFiles })
+      if (!completeRes.success) {
+        throw new Error(completeRes.message || '파일 업로드 완료 처리 실패')
       }
 
       completeStep(2)
@@ -347,6 +347,8 @@ export function InterviewSetupModal({ session, isResume = false }: InterviewSetu
                     title: title.trim() || '모의 면접',
                     basePose: cameraHandler.basePose,
                     stream: cameraHandler.cameraStream,
+                    interviewId,
+                    questions: questions ?? [],
                   })
                 }}
                 className="gap-2"

--- a/src/featured/interview/components/screen/ControlBar.tsx
+++ b/src/featured/interview/components/screen/ControlBar.tsx
@@ -4,13 +4,13 @@ import Link from 'next/link'
 import { Button } from '@/shared/ui/button'
 import { Mic, MicOff, Video, VideoOff, SkipForward, CheckCircle2, ChevronRight } from 'lucide-react'
 import type { Phase } from '@/featured/interview/types'
-import { QUESTIONS } from '@/featured/interview/constants'
 
 interface ControlBarProps {
   micOn: boolean
   cameraOn: boolean
   phase: Phase
   currentQuestion: number
+  questionCount: number
   onToggleMic: () => void
   onToggleCamera: () => void
   onStartInterview: () => void
@@ -23,12 +23,15 @@ export function ControlBar({
   cameraOn,
   phase,
   currentQuestion,
+  questionCount,
   onToggleMic,
   onToggleCamera,
   onStartInterview,
   onStartAnswering,
   onNext,
 }: ControlBarProps) {
+  const isLastQuestion = questionCount > 0 && currentQuestion >= questionCount - 1
+
   return (
     <div className="relative z-20 flex items-center justify-center gap-3 border-t border-white/10 bg-slate-900/80 px-4 py-4 backdrop-blur">
       <Button
@@ -63,7 +66,7 @@ export function ControlBar({
       )}
       {phase === 'answering' && (
         <Button variant="secondary" className="ml-4 gap-2" size="lg" onClick={onNext}>
-          {currentQuestion < QUESTIONS.length - 1 ? (
+          {!isLastQuestion ? (
             <>
               다음 질문
               <SkipForward className="h-4 w-4" />

--- a/src/featured/interview/components/screen/QuestionBanner.tsx
+++ b/src/featured/interview/components/screen/QuestionBanner.tsx
@@ -3,11 +3,12 @@
 import { motion, AnimatePresence } from 'framer-motion'
 import { CheckCircle2 } from 'lucide-react'
 import { TypingText } from '@/featured/interview/components/screen/TypingText'
-import { QUESTIONS } from '@/featured/interview/constants'
+import type { InterviewQuestions } from '@/featured/interview/types'
 
 interface QuestionBannerProps {
   isActive: boolean
   currentQuestion: number
+  questions: InterviewQuestions[]
   typingKey: number
   questionRevealed: boolean
   onTypingComplete: () => void
@@ -16,10 +17,13 @@ interface QuestionBannerProps {
 export function QuestionBanner({
   isActive,
   currentQuestion,
+  questions,
   typingKey,
   questionRevealed,
   onTypingComplete,
 }: QuestionBannerProps) {
+  const currentQuestionText = questions[currentQuestion]?.content ?? ''
+
   return (
     <AnimatePresence>
       {isActive && (
@@ -39,12 +43,12 @@ export function QuestionBanner({
               {!questionRevealed ? (
                 <TypingText
                   key={typingKey}
-                  text={QUESTIONS[currentQuestion]}
+                  text={currentQuestionText}
                   speed={28}
                   onComplete={onTypingComplete}
                 />
               ) : (
-                QUESTIONS[currentQuestion]
+                currentQuestionText
               )}
             </p>
             {questionRevealed && (

--- a/src/featured/interview/hooks/useInterview.ts
+++ b/src/featured/interview/hooks/useInterview.ts
@@ -2,8 +2,14 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { QUESTIONS, TOTAL_ANSWER_TIME, TOTAL_THINK_TIME } from '@/featured/interview/constants'
-import type { Phase } from '@/featured/interview/types'
+import { TOTAL_ANSWER_TIME, TOTAL_THINK_TIME } from '@/featured/interview/constants'
+import type { InterviewQuestions, Phase } from '@/featured/interview/types'
+import {
+  completeVideoFileUploadAction,
+  issueVideoPresignedUrlAction,
+  requestAnswerAnalysisAction,
+} from '@/featured/interview/actions/interview.action'
+import uploadFileToS3 from '@/shared/lib/utils/uploadFileToS3'
 import { useVideoRecorder } from '@/featured/interview/hooks/useVideoRecorder'
 
 export function useInterview() {
@@ -22,10 +28,14 @@ export function useInterview() {
   const [interviewTitle, setInterviewTitle] = useState('AI 모의 면접')
   const [basePose, setBasePose] = useState<{ pitch: number; yaw: number } | null>(null)
   const [cameraStream, setCameraStream] = useState<MediaStream | null>(null)
+  const [interviewId, setInterviewId] = useState<number | null>(null)
+  const [interviewQuestions, setInterviewQuestions] = useState<InterviewQuestions[]>([])
 
   const phaseRef = useRef(phase)
   const currentQuestionRef = useRef(currentQuestion)
   const cameraStreamRef = useRef<MediaStream | null>(null)
+  const interviewIdRef = useRef<number | null>(null)
+  const interviewQuestionsRef = useRef<InterviewQuestions[]>([])
 
   const isActive = phase === 'thinking' || phase === 'answering'
 
@@ -40,6 +50,14 @@ export function useInterview() {
   useEffect(() => {
     cameraStreamRef.current = cameraStream
   }, [cameraStream])
+
+  useEffect(() => {
+    interviewIdRef.current = interviewId
+  }, [interviewId])
+
+  useEffect(() => {
+    interviewQuestionsRef.current = interviewQuestions
+  }, [interviewQuestions])
 
   const cleanupInterviewMedia = useCallback(() => {
     const stream = cameraStreamRef.current
@@ -59,10 +77,14 @@ export function useInterview() {
     title?: string
     basePose?: { pitch: number; yaw: number } | null
     stream?: MediaStream | null
+    interviewId?: number | null
+    questions?: InterviewQuestions[]
   }) => {
     setInterviewTitle(config.title || 'AI 모의 면접')
     setBasePose(config.basePose ?? null)
     setCameraStream(config.stream ?? null)
+    setInterviewId(config.interviewId ?? null)
+    setInterviewQuestions(config.questions ?? [])
     setShowSetup(false)
     setTypingKey((prev) => prev + 1)
     setQuestionRevealed(false)
@@ -87,8 +109,61 @@ export function useInterview() {
 
   const handleNext = useCallback(async () => {
     const questionIndex = currentQuestionRef.current
-    await stopRecording()
-    if (questionIndex < QUESTIONS.length - 1) {
+    const videoBlob = (await stopRecording()) as Blob
+
+    try {
+      const currentInterviewId = interviewIdRef.current
+      const currentQuestionSet = interviewQuestionsRef.current[questionIndex]
+
+      if (!currentInterviewId || !currentQuestionSet) {
+        throw new Error('영상 업로드에 필요한 인터뷰 정보가 없습니다.')
+      }
+
+      const videoFile = new File(
+        [videoBlob],
+        `answer-${currentQuestionSet.questionSetId}-${Date.now()}.webm`,
+        {
+          type: videoBlob.type || 'video/webm',
+        },
+      )
+
+      const urlRes = await issueVideoPresignedUrlAction(currentQuestionSet.questionSetId, {
+        video: {
+          originalFileName: videoFile.name,
+          contentType: videoFile.type,
+          fileSizeBytes: videoFile.size,
+        },
+      })
+
+      if (!urlRes.success || !urlRes.data) {
+        throw new Error(urlRes.message || '영상 Presigned URL 발급 실패')
+      }
+
+      const s3Res = await uploadFileToS3(videoFile, urlRes.data.presignedUrl)
+      if (!s3Res.success) {
+        throw new Error(s3Res.message)
+      }
+
+      const completeRes = await completeVideoFileUploadAction(currentQuestionSet.questionSetId, {
+        originalFileName: urlRes.data.originalFileName,
+        fileKey: urlRes.data.fileKey,
+        fileUrl: urlRes.data.fileUrl,
+        contentType: videoFile.type,
+        fileSizeBytes: videoFile.size,
+      })
+
+      const answerId = completeRes.data?.answerId
+      if (!answerId) {
+        throw new Error('답변 업로드 완료 응답에 answerId가 없습니다.')
+      }
+
+      await requestAnswerAnalysisAction(answerId)
+    } catch (error: unknown) {
+      console.error(error instanceof Error ? error.message : '답변 처리 중 오류가 발생했습니다.')
+    }
+
+    const totalQuestions = interviewQuestionsRef.current.length
+    if (questionIndex < totalQuestions - 1) {
       setPhase('transition')
       setTimeout(() => {
         setCurrentQuestion((prev) => prev + 1)
@@ -155,6 +230,7 @@ export function useInterview() {
 
   return {
     currentQuestion,
+    interviewQuestions,
     phase,
     timeLeft,
     micOn,

--- a/src/featured/interview/services/interview.service.ts
+++ b/src/featured/interview/services/interview.service.ts
@@ -6,7 +6,12 @@ import {
   GetInterviewQuestionsResponse,
   IssuePresignedUrlRequest,
   IssuePresignedUrlResponse,
+  IssueVideoPresignedUrlResponse,
   UpdateInterviewTitleResponse,
+  IssueVideoPresignedUrlRequest,
+  VideoInfo,
+  CompleteVideoFileUploadResponse,
+  AnswerAnalysisResponse,
 } from '../types'
 
 // 면접 생성(제목 추가)
@@ -62,6 +67,33 @@ export async function getInterviewQuestions(
   intvId: number,
 ): Promise<ApiResponse<GetInterviewQuestionsResponse>> {
   return await serverApi.get(`/api/v1/intvs/${intvId}/questions`)
+}
+
+// 답변 영상 업로드 presignedUrl 발급
+export async function issueVideoPresignedUrl(
+  questionSetId: number,
+  video: IssueVideoPresignedUrlRequest,
+): Promise<ApiResponse<IssueVideoPresignedUrlResponse>> {
+  return await serverApi.post(`/api/v1/intvs/${questionSetId}/answers/presigned-url`, {
+    video: video,
+  })
+}
+
+// 답변 영상 업로드 완료
+export async function completeVideoFileUpload(
+  questionSetId: number,
+  video: VideoInfo,
+): Promise<ApiResponse<CompleteVideoFileUploadResponse>> {
+  return await serverApi.post(`/api/v1/intvs/${questionSetId}/answers`, {
+    video: video,
+  })
+}
+
+// 답변 분석 요청
+export async function requestAnswerAnalysis(
+  answerId: number,
+): Promise<ApiResponse<AnswerAnalysisResponse>> {
+  return await serverApi.post(`/api/v1/answers/${answerId}/analysis`)
 }
 
 // 면접 시작

--- a/src/featured/interview/types.ts
+++ b/src/featured/interview/types.ts
@@ -88,18 +88,18 @@ export interface UpdateInterviewTitleResponse {
   status: string
 }
 
-export interface IssuePresignedUrlRequest {
-  fileType: InterviewFileType
-  originalFileName: string
-  contentType: string
-  fileSizeBytes: number
-}
-
 export interface FileInfo {
   fileType: string
   originalFileName: string
   fileKey: string
   fileUrl: string
+}
+
+export interface IssuePresignedUrlRequest {
+  fileType: InterviewFileType
+  originalFileName: string
+  contentType: string
+  fileSizeBytes: number
 }
 
 export interface IssuePresignedUrlResponse {
@@ -136,4 +136,42 @@ export interface InterviewQuestions {
 export interface GetInterviewQuestionsResponse {
   intvId: number
   questions: InterviewQuestions[]
+}
+
+export interface IssueVideoPresignedUrlRequest {
+  originalFileName: string
+  contentType: string // 테스트 후 타입 좁히기 필요
+  fileSizeBytes: number
+}
+
+export interface IssueVideoPresignedUrlResponse {
+  questionSetId: number
+  originalFileName: string
+  fileKey: string
+  presignedUrl: string
+  fileUrl: string
+  expiresInSeconds: number
+}
+
+export interface VideoInfo {
+  originalFileName: string
+  fileKey: string
+  fileUrl: string
+  contentType: string
+  fileSizeBytes: number
+}
+
+export interface CompleteVideoFileUploadResponse {
+  answerId: number
+  questionSetId: number
+  originalFileName: string
+  fileKey: string
+  fileUrl: string
+  contentType: string
+  fileSizeBytes: number
+}
+
+export interface AnswerAnalysisResponse {
+  answerId: number
+  analysisStatus: string
 }

--- a/src/shared/lib/utils/uploadFileToS3.ts
+++ b/src/shared/lib/utils/uploadFileToS3.ts
@@ -2,7 +2,7 @@ async function uploadFileToS3(file: File, presignedUrl: string) {
   const response = await fetch(presignedUrl, {
     method: 'PUT',
     body: file,
-    headers: { 'Content-Type': 'application/pdf' },
+    headers: { 'Content-Type': file.type },
   })
   if (response.ok) {
     return {


### PR DESCRIPTION
## 변경 사항

- 실시간 질문 노출 UI
폴링을 통해 서버로부터 받아온 questions 배열을 상단 배너 형식으로 시각화
- Presigned URL 발급 및 S3 업로드 로직 구현
S3 직접 업로드를 위해 보안 인증된 URL을 발급
- 답변 영상 데이터베이스 기록
S3 업로드 성공 후, 발급받은 파일 경로를 백엔드 서버에 전달하여 답변 데이터를 생성
- AI 답변 분석 요청 트리거
답변 생성이 완료된 후, AI 분석 엔진에 분석 시작을 요청

close #140 
